### PR TITLE
[2.8.0] Improve the default option when it receives a proc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 
 name: build
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ So, if you change [[1](#with_attribute)] [[2](#with_attributes)] an attribute of
 Version    | Documentation
 ---------- | -------------
 unreleased | https://github.com/serradura/u-case/blob/main/README.md
-2.7.0      | https://github.com/serradura/u-case/blob/v2.x/README.md
+2.8.0      | https://github.com/serradura/u-case/blob/v2.x/README.md
 1.2.0      | https://github.com/serradura/u-case/blob/v1.x/README.md
 
 # Table of contents <!-- omit in toc -->
@@ -94,7 +94,7 @@ gem 'u-attributes'
 | u-attributes   | branch  | ruby     |  activemodel  |
 | -------------- | ------- | -------- | ------------- |
 | unreleased     | main    | >= 2.2.0 | >= 3.2, < 7   |
-| 2.7.0          | v2.x    | >= 2.2.0 | >= 3.2, < 7   |
+| 2.8.0          | v2.x    | >= 2.2.0 | >= 3.2, < 7   |
 | 1.2.0          | v1.x    | >= 2.2.0 | >= 3.2, < 6.1 |
 
 > **Note**: The activemodel is an optional dependency, this module [can be enabled](#activemodelvalidation-extension) to validate the attributes.

--- a/lib/micro/attributes.rb
+++ b/lib/micro/attributes.rb
@@ -128,7 +128,7 @@ module Micro
 
         value_to_assign =
           if default.is_a?(Proc) && !keep_proc
-            default.arity > 0 ? default.call(value) : default.call
+            default.arity == 0 ? default.call : default.call(value)
           else
             value.nil? ? default : value
           end

--- a/lib/micro/attributes/features/accept.rb
+++ b/lib/micro/attributes/features/accept.rb
@@ -35,10 +35,10 @@ module Micro::Attributes
 
         KeepProc = -> validation_data { validation_data[0] == :accept && validation_data[1] == Proc }
 
-        def __attribute_assign(key, initialize_value, attribute_data)
+        def __attribute_assign(key, init_hash, attribute_data)
           validation_data = attribute_data[1]
 
-          value_to_assign = FetchValueToAssign.(initialize_value, attribute_data, KeepProc.(validation_data))
+          value_to_assign = FetchValueToAssign.(init_hash, init_hash[key], attribute_data, KeepProc.(validation_data))
 
           value = __attributes[key] = instance_variable_set("@#{key}", value_to_assign)
 

--- a/lib/micro/attributes/version.rb
+++ b/lib/micro/attributes/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   module Attributes
-    VERSION = '2.7.0'.freeze
+    VERSION = '2.8.0'.freeze
   end
 end

--- a/test/micro/attributes/defaults_test.rb
+++ b/test/micro/attributes/defaults_test.rb
@@ -52,6 +52,27 @@ class Micro::Attributes::DefaultsTest < Minitest::Test
     assert attributes.b.strftime('%H:%M:%S') == attributes.c.strftime('%H:%M:%S')
   end
 
+  class ArityOne
+    include Micro::Attributes.with(:initialize)
+
+    attribute :str, default: ->(value) { value.to_s }
+    attributes :number1, :number2, default: ->(value) { (value || 0).to_i }
+  end
+
+  def test_default_receiving_a_lambda_with_1_as_its_arity
+    attributes1 = ArityOne.new(str: 1)
+
+    assert_equal('1', attributes1.str)
+    assert_equal(0, attributes1.number1)
+    assert_equal(0, attributes1.number2)
+
+    attributes2 = ArityOne.new(str: 2, number2: '10')
+
+    assert_equal('2', attributes2.str)
+    assert_equal(0, attributes2.number1)
+    assert_equal(10, attributes2.number2)
+  end
+
   class ProcWithToProc
     include Micro::Attributes.with(:initialize)
 

--- a/test/micro/attributes/defaults_test.rb
+++ b/test/micro/attributes/defaults_test.rb
@@ -73,6 +73,25 @@ class Micro::Attributes::DefaultsTest < Minitest::Test
     assert_equal(10, attributes2.number2)
   end
 
+  class ArityTwo
+    include Micro::Attributes.with(:initialize)
+
+    attribute :float, default: ->(value, raw_input) { (value || raw_input['integer']).to_f }
+    attribute :integer, default: ->(value) { value.to_i }
+  end
+
+  def test_default_receiving_a_lambda_with_2_as_its_arity
+    attributes1 = ArityTwo.new(integer: '2')
+
+    assert_equal(2.0, attributes1.float)
+    assert_equal(2, attributes1.integer)
+
+    attributes2 = ArityTwo.new(float: 1.5, integer: '3')
+
+    assert_equal(1.5, attributes2.float)
+    assert_equal(3, attributes2.integer)
+  end
+
   class ProcWithToProc
     include Micro::Attributes.with(:initialize)
 

--- a/test/micro/attributes/defaults_test.rb
+++ b/test/micro/attributes/defaults_test.rb
@@ -35,4 +35,20 @@ class Micro::Attributes::DefaultsTest < Minitest::Test
     assert_equal(5, Sum.new(b: 3).call)
     assert_equal(5, Sum.new(a: 2, b: 3).call)
   end
+
+  class ArityZero
+    include Micro::Attributes.with(:initialize)
+
+    attribute :a, default: -> { Time.now }
+    attributes :b, :c, default: -> { Time.now + 1 }
+  end
+
+  def test_default_receiving_a_lambda_with_0_as_its_arity
+    attributes = ArityZero.new({})
+
+    assert attributes.b > attributes.a
+    assert attributes.c > attributes.a
+    assert attributes.b != attributes.c
+    assert attributes.b.strftime('%H:%M:%S') == attributes.c.strftime('%H:%M:%S')
+  end
 end

--- a/test/micro/attributes/defaults_test.rb
+++ b/test/micro/attributes/defaults_test.rb
@@ -51,4 +51,16 @@ class Micro::Attributes::DefaultsTest < Minitest::Test
     assert attributes.b != attributes.c
     assert attributes.b.strftime('%H:%M:%S') == attributes.c.strftime('%H:%M:%S')
   end
+
+  class ProcWithToProc
+    include Micro::Attributes.with(:initialize)
+
+    attribute :str, default: proc(&:to_s)
+  end
+
+  def test_default_receiving_to_proc
+    assert_equal('', ProcWithToProc.new(str: nil).str)
+    assert_equal('1', ProcWithToProc.new(str: 1).str)
+    assert_equal('a', ProcWithToProc.new(str: :a).str)
+  end
 end


### PR DESCRIPTION
- Allow the usage of `to_proc` with the `proc` method:

```ruby
class Person
  include Micro::Attributes.with(:initialize)
 
  attribute :name, default: proc(&:to_s)
end
```

- When the default option lambda / proc has two arguments the second one will be the raw input.
```ruby
class Numbers
  include Micro::Attributes.with(:initialize)

  attribute :float, default: ->(value, raw_input) { (value || raw_input['integer']).to_f }
  attribute :integer, default: ->(value) { value.to_i }
end
```
