### PR TITLE
Allow defaults with lambdas of arity 0 to be overriden

### DIFF
--- a/lib/micro/attributes.rb
+++ b/lib/micro/attributes.rb
@@ -129,7 +129,7 @@ module Micro
         value_to_assign =
           if default.is_a?(Proc) && !keep_proc
             case default.arity
-            when 0 then default.call
+            when 0 then value.nil? ? default.call : value
             when 2 then default.call(value, init_hash)
             else default.call(value)
             end

--- a/test/micro/attributes/defaults_test.rb
+++ b/test/micro/attributes/defaults_test.rb
@@ -39,17 +39,24 @@ class Micro::Attributes::DefaultsTest < Minitest::Test
   class ArityZero
     include Micro::Attributes.with(:initialize)
 
-    attribute :a, default: -> { Time.now }
-    attributes :b, :c, default: -> { Time.now + 1 }
+    attribute :a, default: -> { 0 }
+    attributes :b, :c, default: -> { 1 }
   end
 
   def test_default_receiving_a_lambda_with_0_as_its_arity
     attributes = ArityZero.new({})
 
-    assert attributes.b > attributes.a
-    assert attributes.c > attributes.a
-    assert attributes.b != attributes.c
-    assert attributes.b.strftime('%H:%M:%S') == attributes.c.strftime('%H:%M:%S')
+    assert_equal(0, attributes.a)
+    assert_equal(1, attributes.b)
+    assert_equal(1, attributes.c)
+  end
+
+  def test_overriding_default_receiving_a_lambda_with_0_as_its_arity
+    attributes = ArityZero.new(a: 1, b: 2, c: 3)
+
+    assert_equal(1, attributes.a)
+    assert_equal(2, attributes.b)
+    assert_equal(3, attributes.c)
   end
 
   class ArityOne


### PR DESCRIPTION
Hi Rodrigo! :wave: 

Let me start by thanking you for your work on the "micro" family of gems. Great stuff!

I stumped across this bug earlier today. I couldn't override a default when playing around with u-case, and I had to understand why. Here is why.

As a more general remark, the `default` optional seems somewhat overloaded. Maybe we could move the value preprocessing behavior to a different option. What do you think? It would be a breaking change.

Obrigado! :trophy: