### PR TITLE
Bump to 3.0.0 + refresh README docs and add Ruby/Rails matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Version    | Documentation
 unreleased | https://github.com/serradura/u-attributes/blob/main/README.md
 3.0.0      | https://github.com/serradura/u-attributes/blob/v3.x/README.md
 2.8.0      | https://github.com/serradura/u-attributes/blob/v2.x/README.md
-1.2.0      | https://github.com/serradura/u-attributes/blob/v1.x/README.md
 
 # Table of contents <!-- omit in toc -->
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -1,28 +1,16 @@
 <p align="center">
-  <img src="./assets/u-attributes_logo_v1.png" alt='Create "immutable" objects. No setters, just getters!'>
-
+  <h1 align="center" id="-attributes"><img src="./assets/u-attributes_logo_v1.png" alt="μ-attributes" height="60"></h1>
   <p align="center"><i>Create "immutable" objects with no setters, just getters.</i></p>
-  <br>
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/ruby->%3D%202.7-ruby.svg?colorA=99004d&colorB=cc0066" alt="Ruby">
-
-  <a href="https://rubygems.org/gems/u-attributes">
-    <img alt="Gem" src="https://img.shields.io/gem/v/u-attributes.svg?style=flat-square">
-  </a>
-
-  <a href="https://github.com/serradura/u-attributes/actions/workflows/ci.yml">
-    <img alt="Build Status" src="https://github.com/serradura/u-attributes/actions/workflows/ci.yml/badge.svg">
-  </a>
-
-  <a href="https://qlty.sh/gh/serradura/projects/u-attributes">
-    <img alt="Maintainability" src="https://qlty.sh/gh/serradura/projects/u-attributes/maintainability.svg">
-  </a>
-
-  <a href="https://qlty.sh/gh/serradura/projects/u-attributes">
-    <img alt="Code Coverage" src="https://qlty.sh/gh/serradura/projects/u-attributes/coverage.svg">
-  </a>
+  <p align="center">
+    <a href="https://badge.fury.io/rb/u-attributes"><img src="https://badge.fury.io/rb/u-attributes.svg" alt="Gem Version" height="18"></a>
+    <a href="https://github.com/serradura/u-attributes/actions/workflows/ci.yml"><img alt="Build Status" src="https://github.com/serradura/u-attributes/actions/workflows/ci.yml/badge.svg"></a>
+    <br/>
+    <a href="https://qlty.sh/gh/serradura/projects/u-attributes"><img src="https://qlty.sh/gh/serradura/projects/u-attributes/maintainability.svg" alt="Maintainability" /></a>
+    <a href="https://qlty.sh/gh/serradura/projects/u-attributes"><img src="https://qlty.sh/gh/serradura/projects/u-attributes/coverage.svg" alt="Code Coverage" /></a>
+    <br/>
+    <img src="https://img.shields.io/badge/Ruby%20%3E%3D%202.7%2C%20%3C%3D%20Head-ruby.svg?colorA=444&colorB=333" alt="Ruby">
+    <img src="https://img.shields.io/badge/Rails%20%3E%3D%206.0%2C%20%3C%3D%20Edge-rails.svg?colorA=444&colorB=333" alt="Rails">
+  </p>
 </p>
 
 This gem allows you to define "immutable" objects, when using it your objects will only have getters and no setters.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ So, if you change [[1](#with_attribute)] [[2](#with_attributes)] an attribute of
 
 Version    | Documentation
 ---------- | -------------
-unreleased | https://github.com/serradura/u-case/blob/main/README.md
-2.8.0      | https://github.com/serradura/u-case/blob/v2.x/README.md
-1.2.0      | https://github.com/serradura/u-case/blob/v1.x/README.md
+unreleased | https://github.com/serradura/u-attributes/blob/main/README.md
+3.0.0      | https://github.com/serradura/u-attributes/blob/v3.x/README.md
+2.8.0      | https://github.com/serradura/u-attributes/blob/v2.x/README.md
+1.2.0      | https://github.com/serradura/u-attributes/blob/v1.x/README.md
 
 # Table of contents <!-- omit in toc -->
 - [Installation](#installation)
@@ -89,16 +90,30 @@ unreleased | https://github.com/serradura/u-case/blob/main/README.md
 Add this line to your application's Gemfile and `bundle install`:
 
 ```ruby
-gem 'u-attributes'
+gem 'u-attributes', '~> 3.0'
 ```
 
 # Compatibility
 
-| u-attributes   | branch  | ruby     |  activemodel  |
-| -------------- | ------- | -------- | ------------- |
-| unreleased     | main    | >= 2.2.0 | >= 3.2, < 7   |
-| 2.8.0          | v2.x    | >= 2.2.0 | >= 3.2, < 7   |
-| 1.2.0          | v1.x    | >= 2.2.0 | >= 3.2, < 6.1 |
+| u-attributes     | branch | ruby     | activemodel    |
+| ---------------- | ------ | -------- | -------------- |
+| unreleased       | main   | >= 2.7   | >= 6.0         |
+| 3.0.0            | v3.x   | >= 2.7   | >= 6.0         |
+| 2.8.0            | v2.x   | >= 2.2.0 | >= 3.2, <= 8.1 |
+| 1.2.0            | v1.x   | >= 2.2.0 | >= 3.2, < 6.1  |
+
+This library is tested (CI matrix) against:
+
+| Ruby / Rails | 6.0 | 6.1 | 7.0 | 7.1 | 7.2 | 8.0 | 8.1 | Edge |
+|--------------|-----|-----|-----|-----|-----|-----|-----|------|
+| 2.7          | ✅  | ✅  | ✅  | ✅  |     |     |     |      |
+| 3.0          | ✅  | ✅  | ✅  | ✅  |     |     |     |      |
+| 3.1          |     |     | ✅  | ✅  | ✅  |     |     |      |
+| 3.2          |     |     | ✅  | ✅  | ✅  | ✅  |     |      |
+| 3.3          |     |     | ✅  | ✅  | ✅  | ✅  | ✅  | ✅   |
+| 3.4          |     |     |     |     | ✅  | ✅  | ✅  | ✅   |
+| 4.x          |     |     |     |     |     |     | ✅  | ✅   |
+| Head         |     |     |     |     |     |     | ✅  | ✅   |
 
 > **Note**: The activemodel is an optional dependency, this module [can be enabled](#activemodelvalidation-extension) to validate the attributes.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ gem 'u-attributes', '~> 3.0'
 | unreleased       | main   | >= 2.7   | >= 6.0         |
 | 3.0.0            | v3.x   | >= 2.7   | >= 6.0         |
 | 2.8.0            | v2.x   | >= 2.2.0 | >= 3.2, <= 8.1 |
-| 1.2.0            | v1.x   | >= 2.2.0 | >= 3.2, < 6.1  |
 
 This library is tested (CI matrix) against:
 

--- a/lib/micro/attributes/version.rb
+++ b/lib/micro/attributes/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   module Attributes
-    VERSION = '2.8.0'.freeze
+    VERSION = '3.0.0'.freeze
   end
 end


### PR DESCRIPTION
## Summary
Major version bump to mark the Ruby floor change that landed in #42 (gemspec `required_ruby_version` raised from `>= 2.2.0` to `>= 2.7.0`). Users still on Ruby 2.2..2.6 should stay on the `~> 2.8` series.

### Changes
- `lib/micro/attributes/version.rb`: `2.8.0` → `3.0.0`.
- `README.md`:
  - Compatibility table updated: `3.0.0 / v3.x` is now the active line (`ruby >= 2.7`, `activemodel >= 6.0`); `2.8.0 / v2.x` row preserved with its actual support range (`activemodel >= 3.2, <= 8.1`).
  - **Added a Ruby × Rails support matrix** (ported from solid-process) so the supported combinations are visible at a glance.
  - Version-doc table now points to `u-attributes` (was incorrectly pointing to `u-case`) and adds the `3.0.0` row.
  - Installation snippet pins to `~> 3.0`.

## Release checklist (once merged)
- [ ] `bundle exec rake release` (or manual `gem push`) to publish `u-attributes-3.0.0`
- [ ] Cut a `v3.x` branch so the docs link in the README resolves
- [ ] Coordinate with u-case 5.0 (which already declares `>= 2.7` and depends on `u-attributes >= 2.7, < 3.0` — needs a bump to `< 4.0` to pull in 3.0)

## Test plan
- [ ] CI still green on the full Ruby 2.7..head / Rails 6.0..edge matrix (no behavior changes in this PR; only version + README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)