### PR TITLE
docs: state no-breaking-API-changes policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Notes for AI assistants working in `u-attributes`.
 
+## Golden rule: no breaking API changes — ever
+
+`u-attributes` is a runtime dependency of [`u-case`](https://github.com/serradura/u-case), whose own public API is frozen. **The same compromise applies here:** the public API and runtime contracts of `u-attributes` won't break. Every change must keep existing code working — both for direct users of the gem and for `u-case` (and everything that transitively depends on it).
+
+Major version bumps are reserved for dependency-floor changes (dropping a Ruby or `activemodel` version from the supported matrix) per SemVer. They do **not** signal a behavior break.
+
+If a task as stated would require a breaking change to honor it, stop and surface that — propose a backward-compatible path, or flag that the request can't be satisfied without violating this rule. Don't ship the break.
+
 ## How to work in this repo
 
 ### 1. Think before coding

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@
   </p>
 </p>
 
+> [!IMPORTANT]
+> **No breaking API changes — ever.** `u-attributes` is a runtime dependency of [`u-case`](https://github.com/serradura/u-case), whose own public API is frozen — so the same compromise applies here. The gem's role is to remain a stable, backward-compatible foundation for every project (directly or transitively) that depends on it.
+>
+> Major version bumps signal only that a Ruby or `activemodel` version was dropped from the supported matrix — per SemVer, a dependency-floor change. Your code keeps working.
+
 `u-attributes` lets you define classes whose instances expose attribute readers but no setters. Mutation goes through [`#with_attribute`](#with_attribute) / [`#with_attributes`](#with_attributes), which return a new instance — you transform the object instead of modifying it.
 
 ## Why u-attributes? <!-- omit in toc -->


### PR DESCRIPTION
## Summary

- Encode the same stability compromise as `u-case` into `u-attributes`: because `u-attributes` is a runtime dependency of `u-case` (whose public API is frozen), its own public API and runtime contracts are frozen too.
- Add a **Golden rule: no breaking API changes — ever** section at the top of `CLAUDE.md` so AI assistants working in the repo treat this as load-bearing — propose backward-compatible paths or surface conflicts rather than ship a break.
- Add an `> [!IMPORTANT]` callout at the top of `README.md` (parallel to the one on `u-case`) so the stance is visible to direct readers as well.

Major version bumps remain reserved for dependency-floor changes (Ruby / `activemodel`) per SemVer; no behavior breaks.

## Test plan

- [x] Docs-only change — no code or tests touched
- [x] Skim the rendered README on GitHub to confirm the `[!IMPORTANT]` callout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)